### PR TITLE
Add registration and profile-based menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,9 @@
         <activity android:name=".ZooEditActivity" />
         <activity android:name=".EspecieEditActivity" />
         <activity android:name=".MainMenuActivity" />
+        <activity android:name=".UserMenuActivity" />
         <activity android:name=".ForgotPasswordActivity" />
+        <activity android:name=".RegisterActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/practica/proyectozoo/LoginActivity.kt
+++ b/app/src/main/java/com/practica/proyectozoo/LoginActivity.kt
@@ -41,8 +41,9 @@ class LoginActivity : ComponentActivity() {
                     // Formulario en el centro
                     SimpleLogin(
                         db = db,
-                        onSuccess = { ctx ->
-                            ctx.startActivity(Intent(ctx, MainMenuActivity::class.java))
+                        onSuccess = { ctx, perfil ->
+                            if (perfil == 1) ctx.startActivity(Intent(ctx, MainMenuActivity::class.java))
+                            else ctx.startActivity(Intent(ctx, UserMenuActivity::class.java))
                             finish()
                         },
                         modifier = Modifier
@@ -58,7 +59,7 @@ class LoginActivity : ComponentActivity() {
 @Composable
 fun SimpleLogin(
     db: DatabaseHelper,
-    onSuccess: (ctx: android.content.Context) -> Unit,
+    onSuccess: (ctx: android.content.Context, perfil: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var user by rememberSaveable { mutableStateOf("") }
@@ -131,7 +132,10 @@ fun SimpleLogin(
                             Toast.makeText(ctx, errLogin, Toast.LENGTH_SHORT).show()
                             showError = true
                         }
-                        else -> onSuccess(ctx)
+                        else -> {
+                            val perfil = db.getPerfilId(user, pass) ?: 1
+                            onSuccess(ctx, perfil)
+                        }
                     }
                 },
                 modifier = Modifier
@@ -145,6 +149,11 @@ fun SimpleLogin(
                 ctx.startActivity(Intent(ctx, ForgotPasswordActivity::class.java))
             }) {
                 Text(btnForgot)
+            }
+            TextButton(onClick = {
+                ctx.startActivity(Intent(ctx, RegisterActivity::class.java))
+            }) {
+                Text(stringResource(R.string.register))
             }
             if (showError) {
                 Spacer(Modifier.height(8.dp))
@@ -166,8 +175,8 @@ fun PreviewSimpleLogin() {
         ) {
             SimpleLogin(
                 db = db,
-                onSuccess = {},
-                modifier = Modifier.align(Alignment.Center)
+                onSuccess = { _, _ -> },
+                modifier = Modifier.align(Alignment.Center),
             )
         }
     }

--- a/app/src/main/java/com/practica/proyectozoo/RegisterActivity.kt
+++ b/app/src/main/java/com/practica/proyectozoo/RegisterActivity.kt
@@ -1,0 +1,130 @@
+package com.practica.proyectozoo
+
+import android.os.Bundle
+import android.util.Patterns
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.practica.proyectozoo.data.DatabaseHelper
+import com.practica.proyectozoo.ui.theme.EarthBrown
+import com.practica.proyectozoo.ui.theme.JungleGreen
+import com.practica.proyectozoo.ui.theme.ProyectozooTheme
+
+class RegisterActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val db = DatabaseHelper(this)
+        setContent {
+            ProyectozooTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Brush.verticalGradient(listOf(JungleGreen, EarthBrown)))
+                        .padding(16.dp)
+                ) {
+                    RegisterScreen(db = db, modifier = Modifier.align(Alignment.Center)) { finish() }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun RegisterScreen(db: DatabaseHelper, modifier: Modifier = Modifier, onRegistered: () -> Unit) {
+    var username by rememberSaveable { mutableStateOf("") }
+    var email by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var confirm by rememberSaveable { mutableStateOf("") }
+    val ctx = LocalContext.current
+
+    val lblUser = stringResource(R.string.username)
+    val lblEmail = stringResource(R.string.email)
+    val lblPwd = stringResource(R.string.password)
+    val lblConf = stringResource(R.string.confirm_password)
+    val btnReg = stringResource(R.string.register)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            OutlinedTextField(
+                value = username,
+                onValueChange = { username = it },
+                label = { Text(lblUser) },
+                leadingIcon = { Icon(Icons.Default.Person, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text(lblEmail) },
+                leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text(lblPwd) },
+                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = confirm,
+                onValueChange = { confirm = it },
+                label = { Text(lblConf) },
+                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    when {
+                        !username.matches(Regex("^[A-Za-z0-9]+$")) -> Toast.makeText(ctx, stringResource(R.string.invalid_username), Toast.LENGTH_SHORT).show()
+                        !Patterns.EMAIL_ADDRESS.matcher(email).matches() -> Toast.makeText(ctx, stringResource(R.string.invalid_email), Toast.LENGTH_SHORT).show()
+                        password.isBlank() -> Toast.makeText(ctx, stringResource(R.string.invalid_password), Toast.LENGTH_SHORT).show()
+                        confirm != password -> Toast.makeText(ctx, stringResource(R.string.password_mismatch), Toast.LENGTH_SHORT).show()
+                        db.validateUser(username, password) -> Toast.makeText(ctx, stringResource(R.string.user_already_exists), Toast.LENGTH_SHORT).show()
+                        else -> {
+                            db.insertUsuario(username, email, password, 2)
+                            Toast.makeText(ctx, stringResource(R.string.registration_success), Toast.LENGTH_LONG).show()
+                            onRegistered()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(btnReg)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/practica/proyectozoo/UserMenuActivity.kt
+++ b/app/src/main/java/com/practica/proyectozoo/UserMenuActivity.kt
@@ -1,0 +1,140 @@
+package com.practica.proyectozoo
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Eco
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practica.proyectozoo.ui.theme.ProyectozooTheme
+
+class UserMenuActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ProyectozooTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = Color(0xFFF8FAFC)
+                ) {
+                    UserMenuScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun UserMenuScreen() {
+    val ctx = LocalContext.current
+
+    val menuItems = listOf(
+        MenuItemData(
+            title = "Zoos",
+            description = "Consultar zoológicos",
+            icon = Icons.Default.Home,
+            backgroundColor = Color(0xFFDBEAFE),
+            iconColor = Color(0xFF3B82F6),
+            onClick = { ctx.startActivity(Intent(ctx, ZooListActivity::class.java)) }
+        ),
+        MenuItemData(
+            title = "Especies",
+            description = "Ver especies registradas",
+            icon = Icons.Default.Eco,
+            backgroundColor = Color(0xFFFEF3C7),
+            iconColor = Color(0xFFF59E0B),
+            onClick = { ctx.startActivity(Intent(ctx, EspecieListActivity::class.java)) }
+        )
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 32.dp, bottom = 16.dp, start = 16.dp, end = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "ProyectoZoo",
+            fontSize = 24.sp,
+            color = Color(0xFF0F172A)
+        )
+        Spacer(Modifier.height(24.dp))
+
+        menuItems.forEach { item ->
+            MenuCard(item)
+        }
+    }
+}
+
+@Composable
+fun MenuCard(item: MenuItemData) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 12.dp)
+            .clickable(onClick = item.onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = item.backgroundColor),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(Color.White, shape = RoundedCornerShape(12.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = item.icon,
+                    contentDescription = null,
+                    tint = item.iconColor
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    fontSize = 16.sp,
+                    color = Color(0xFF0F172A)
+                )
+                Text(
+                    text = item.description,
+                    fontSize = 14.sp,
+                    color = Color(0xFF64748B)
+                )
+            }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = Color(0xFF64748B)
+            )
+        }
+    }
+}
+
+data class MenuItemData(
+    val title: String,
+    val description: String,
+    val icon: ImageVector,
+    val backgroundColor: Color,
+    val iconColor: Color,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/com/practica/proyectozoo/data/DatabaseHelper.kt
+++ b/app/src/main/java/com/practica/proyectozoo/data/DatabaseHelper.kt
@@ -92,7 +92,9 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(
         """)
         // Datos iniciales para prueba
         db.execSQL("INSERT INTO perfiles(nombre_perfil) VALUES('admin');")
+        db.execSQL("INSERT INTO perfiles(nombre_perfil) VALUES('usuario');")
         db.execSQL("INSERT INTO usuarios(username,email,password_hash,id_perfil) VALUES('admin','admin@example.com','admin',1);")
+        db.execSQL("INSERT INTO usuarios(username,email,password_hash,id_perfil) VALUES('user','user@example.com','user',2);")
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
@@ -112,6 +114,15 @@ class DatabaseHelper(context: Context) : SQLiteOpenHelper(
             arrayOf(username, password)
         ).use { cursor ->
             return cursor.moveToFirst()
+        }
+    }
+
+    fun getPerfilId(username: String, password: String): Int? {
+        readableDatabase.rawQuery(
+            "SELECT id_perfil FROM usuarios WHERE username=? AND password_hash=?",
+            arrayOf(username, password)
+        ).use { cursor ->
+            return if (cursor.moveToFirst()) cursor.getInt(0) else null
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,8 @@
     <string name="zoo_not_found">Zoológico no encontrado</string>
     <string name="zoo_deleted">Zoológico eliminado</string>
     <string name="ciudad">Ciudad</string>
+    <string name="register">Registrarse</string>
+    <string name="confirm_password">Confirmar contraseña</string>
+    <string name="password_mismatch">Las contraseñas no coinciden</string>
+    <string name="registration_success">Registro exitoso</string>
 </resources>


### PR DESCRIPTION
## Summary
- seed a standard user profile and user
- expose profile id lookup
- create `RegisterActivity` for new users
- create `UserMenuActivity` for non-admin profile
- load different menu after login depending on profile
- add register link and messages
- register new activities in manifest
